### PR TITLE
Add support to source which pull list of ticks instead of one tick

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,8 +55,8 @@ example-select:
 
 test:
 	docker run --rm -u`id -u`:`id -g` -v $$PWD:/go/src/github.com/kavehmz/bullbear golang:1 /bin/bash -c \
-	cd /go/src/github.com/kavehmz/bullbear;\
-	go test -v --race -cover -coverprofile=cover.out ./...; \
+	cd /go/src/github.com/kavehmz/bullbear && \
+	go test -v --race -cover -coverprofile=cover.out ./... && \
 	go tool cover -func=cover.out | \
 		awk 'END {sub("[.].*","",$$NF); printf "Coverage: %d%%\n", $$NF; \
 			if ($$NF+0 < 100) {print "Coverage is not sufficient"; exit 1}}'

--- a/exchange/exchange.go
+++ b/exchange/exchange.go
@@ -5,10 +5,10 @@ package exchange
 // Exchange represents any source exchange to retrieve data from.
 type Exchange struct {
 	Source interface {
-		Pull(symbol SymbolCode) (*Tick, error)
+		Pull(SymbolCode) ([]*Tick, error)
 	}
 	Store interface {
-		Insert(tick *Tick) error
+		Insert([]*Tick) error
 	}
 }
 

--- a/exchange/exchange_test.go
+++ b/exchange/exchange_test.go
@@ -7,11 +7,11 @@ import (
 
 type source struct{ err bool }
 
-func (s *source) Pull(symbol SymbolCode) (*Tick, error) {
+func (s *source) Pull(symbol SymbolCode) ([]*Tick, error) {
 	if s.err {
 		return nil, errors.New("test_source_error")
 	}
-	return &Tick{Symbol: symbol, Value: 4010500000000}, nil
+	return []*Tick{&Tick{Symbol: symbol, Value: 4010500000000}}, nil
 }
 
 type store struct {
@@ -19,11 +19,11 @@ type store struct {
 	data map[SymbolCode]int64
 }
 
-func (s *store) Insert(tick *Tick) error {
+func (s *store) Insert(ticks []*Tick) error {
 	if s.err {
 		return errors.New("test_store_error")
 	}
-	s.data[tick.Symbol] = tick.Value
+	s.data[ticks[0].Symbol] = ticks[0].Value
 	return nil
 }
 

--- a/exchange/tick.go
+++ b/exchange/tick.go
@@ -10,8 +10,11 @@ type SymbolCode struct {
 // Tick represents market data
 type Tick struct {
 	Timestamp time.Time
-	// Value with nano precision
-	Value int64
 	// e.x BTCUSD
 	Symbol SymbolCode
+	// Value with nano precision
+	Value int64
+	// All with nano precision. They dont exists for all sources
+	Open, High, Low, Close *int64
+	Volume                 *int64
 }

--- a/scheduler/schedule_test.go
+++ b/scheduler/schedule_test.go
@@ -26,12 +26,13 @@ func Test_schedule(t *testing.T) {
 	j := (&Job{}).Define(&exchangeMock{exit: 1}, exchange.SymbolCode{}, time.Nanosecond).Errors(errors)
 	(&Scheduler{}).Add(j).Run()
 
+	testSleepTime := time.Millisecond * 100
 	select {
 	case e := <-errors:
 		if e.Error() != "test_error" {
 			t.Error("expecting error", e)
 		}
-	case <-time.After(time.Millisecond):
+	case <-time.After(testSleepTime):
 		t.Error("expecting error but timed out")
 	}
 
@@ -41,7 +42,7 @@ func Test_schedule(t *testing.T) {
 
 	select {
 	case <-ran:
-	case <-time.After(time.Millisecond):
+	case <-time.After(testSleepTime):
 		t.Error("expecting ran but timed out")
 	}
 
@@ -53,6 +54,6 @@ func Test_schedule(t *testing.T) {
 	select {
 	case <-ran:
 		t.Error("Did expected to get cancelled")
-	case <-time.After(time.Millisecond):
+	case <-time.After(testSleepTime):
 	}
 }

--- a/source/coindesk/coindesk.go
+++ b/source/coindesk/coindesk.go
@@ -27,7 +27,7 @@ type CoinDesk struct {
 
 // Pull retrieves a tick
 // https://api.coindesk.com/v1/bpi/currentprice.json
-func (s *CoinDesk) Pull(symbol exchange.SymbolCode) (*exchange.Tick, error) {
+func (s *CoinDesk) Pull(symbol exchange.SymbolCode) ([]*exchange.Tick, error) {
 	if symbol.Base != "BTC" || symbol.Target != "USD" {
 		return nil, ErrUnsupportedSymbol
 	}
@@ -37,9 +37,9 @@ func (s *CoinDesk) Pull(symbol exchange.SymbolCode) (*exchange.Tick, error) {
 		return nil, err
 	}
 
-	return &exchange.Tick{
+	return []*exchange.Tick{&exchange.Tick{
 		Symbol:    symbol,
 		Value:     int64(resp.Bpi.USD.Ratefloat * 1000000000),
 		Timestamp: resp.Time.UpdatedISO,
-	}, nil
+	}}, nil
 }

--- a/source/coindesk/coindesk_test.go
+++ b/source/coindesk/coindesk_test.go
@@ -44,9 +44,9 @@ func TestCoinDesk_Pull(t *testing.T) {
 		t.Error("expected error", err)
 	}
 
-	tick, err := cd.Pull(exchange.SymbolCode{Base: "BTC", Target: "USD"})
-	if err != nil || tick.Value != 100100000000 || time.Since(tick.Timestamp) > time.Second {
-		t.Error("expected error", err, *tick)
+	ticks, err := cd.Pull(exchange.SymbolCode{Base: "BTC", Target: "USD"})
+	if err != nil || len(ticks) == 0 || ticks[0].Value != 100100000000 || time.Since(ticks[0].Timestamp) > time.Second {
+		t.Error("expected error", err, ticks)
 	}
 
 	c.err = true

--- a/store/influx/influx.go
+++ b/store/influx/influx.go
@@ -14,23 +14,28 @@ type Influx struct {
 }
 
 // Insert save the tick
-func (s *Influx) Insert(tick *exchange.Tick) error {
-	point := client.Point{
-		Measurement: "tick",
-		Tags: map[string]string{
-			"symbol": tick.Symbol.Base + tick.Symbol.Target,
-			"base":   tick.Symbol.Base,
-			"target": tick.Symbol.Target,
-		},
-		Fields: map[string]interface{}{
-			"value": tick.Value,
-		},
-		Time: tick.Timestamp,
+func (s *Influx) Insert(ticks []*exchange.Tick) error {
+	points := []client.Point{}
+	for _, t := range ticks {
+		point := client.Point{
+			Measurement: "tick",
+			Tags: map[string]string{
+				"symbol": t.Symbol.Base + t.Symbol.Target,
+				"base":   t.Symbol.Base,
+				"target": t.Symbol.Target,
+			},
+			Fields: map[string]interface{}{
+				"value": t.Value,
+			},
+			Time: t.Timestamp,
 
-		Precision: "ns",
+			Precision: "ns",
+		}
+		points = append(points, point)
 	}
+
 	bps := client.BatchPoints{
-		Points:   []client.Point{point},
+		Points:   points,
 		Database: s.Database,
 	}
 	_, err := s.Client.Write(bps)

--- a/store/influx/influx_test.go
+++ b/store/influx/influx_test.go
@@ -21,7 +21,7 @@ func (s *influxMock) Write(bp client.BatchPoints) (*client.Response, error) {
 func TestInflux_Insert(t *testing.T) {
 	imock := influxMock{}
 	i := Influx{Client: &imock}
-	err := i.Insert(&exchange.Tick{Value: 1000000000, Timestamp: time.Now(), Symbol: exchange.SymbolCode{Base: "BTC", Target: "USD"}})
+	err := i.Insert([]*exchange.Tick{&exchange.Tick{Value: 1000000000, Timestamp: time.Now(), Symbol: exchange.SymbolCode{Base: "BTC", Target: "USD"}}})
 	if err != nil || imock.bp.Points == nil {
 		t.Error("expected to save data")
 	}


### PR DESCRIPTION
Some sources will return multiple ticks in each pull. We might want to pull less frequently for some types of data (maybe hourly for example) but in each pull we will receive a large amount of data.